### PR TITLE
feat: nighttime/weekend low-load detection and CronHPA template generation

### DIFF
--- a/backend/internal/analyzer/cronhpa.go
+++ b/backend/internal/analyzer/cronhpa.go
@@ -1,0 +1,217 @@
+package analyzer
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+)
+
+// CronHPAConfig holds the configuration for generating a CronHPA template.
+type CronHPAConfig struct {
+	Namespace     string `json:"namespace"`
+	Deployment    string `json:"deployment"`
+	ScaleDownTime string `json:"scale_down_time"` // e.g. "22:00" JST
+	ScaleUpTime   string `json:"scale_up_time"`   // e.g. "06:00" JST
+	MinReplicas   int32  `json:"min_replicas"`
+	MaxReplicas   int32  `json:"max_replicas"`
+}
+
+// cronHPATemplate is the Kubernetes CronJob + kubectl patch YAML template.
+// This pattern is more portable than vendor-specific CronHPA CRDs.
+const cronHPATemplate = `---
+# Scale-down CronJob: reduces replicas during low-load hours
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Deployment }}-scale-down
+  namespace: {{ .Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: infra-miru
+    app.kubernetes.io/part-of: {{ .Deployment }}
+spec:
+  schedule: "{{ .ScaleDownCron }}"
+  timeZone: "Asia/Tokyo"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: {{ .Deployment }}-scaler
+          restartPolicy: OnFailure
+          containers:
+            - name: scale-down
+              image: bitnami/kubectl:latest
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  kubectl patch hpa {{ .Deployment }} \
+                    -n {{ .Namespace }} \
+                    -p '{"spec":{"minReplicas":{{ .MinReplicas }},"maxReplicas":{{ .MaxReplicas }}}}'
+---
+# Scale-up CronJob: restores replicas for normal load hours
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Deployment }}-scale-up
+  namespace: {{ .Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: infra-miru
+    app.kubernetes.io/part-of: {{ .Deployment }}
+spec:
+  schedule: "{{ .ScaleUpCron }}"
+  timeZone: "Asia/Tokyo"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: {{ .Deployment }}-scaler
+          restartPolicy: OnFailure
+          containers:
+            - name: scale-up
+              image: bitnami/kubectl:latest
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  kubectl patch hpa {{ .Deployment }} \
+                    -n {{ .Namespace }} \
+                    -p '{"spec":{"minReplicas":{{ .NormalMinReplicas }},"maxReplicas":{{ .NormalMaxReplicas }}}}'
+---
+# ServiceAccount for the scaler CronJobs
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Deployment }}-scaler
+  namespace: {{ .Namespace }}
+---
+# Role granting permission to patch HPA
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Deployment }}-hpa-patcher
+  namespace: {{ .Namespace }}
+rules:
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    resourceNames: ["{{ .Deployment }}"]
+    verbs: ["get", "patch"]
+---
+# RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Deployment }}-hpa-patcher
+  namespace: {{ .Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Deployment }}-scaler
+    namespace: {{ .Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Deployment }}-hpa-patcher
+  apiGroup: rbac.authorization.k8s.io
+`
+
+// templateData holds the expanded values for YAML rendering.
+type templateData struct {
+	Namespace         string
+	Deployment        string
+	ScaleDownCron     string
+	ScaleUpCron       string
+	MinReplicas       int32
+	MaxReplicas       int32
+	NormalMinReplicas int32
+	NormalMaxReplicas int32
+}
+
+// GenerateCronHPA creates a CronHPAConfig from a ScheduleAnalysis.
+// It picks the earliest and latest low-load hours as scale-down/up boundaries.
+// Default replica counts: low-load min=1, max=2; normal min=2, max=10.
+func GenerateCronHPA(schedule ScheduleAnalysis) CronHPAConfig {
+	scaleDown := "22:00"
+	scaleUp := "06:00"
+
+	if len(schedule.LowLoadHours) > 0 {
+		scaleDown = fmt.Sprintf("%02d:00", schedule.LowLoadHours[0])
+
+		lastLow := schedule.LowLoadHours[len(schedule.LowLoadHours)-1]
+		scaleUpHour := (lastLow + 1) % 24
+		scaleUp = fmt.Sprintf("%02d:00", scaleUpHour)
+	}
+
+	return CronHPAConfig{
+		Namespace:     schedule.Namespace,
+		Deployment:    schedule.Deployment,
+		ScaleDownTime: scaleDown,
+		ScaleUpTime:   scaleUp,
+		MinReplicas:   1,
+		MaxReplicas:   2,
+	}
+}
+
+// RenderCronHPAYAML renders the CronHPA configuration as Kubernetes YAML manifests.
+// The generated YAML includes CronJobs for scale-down and scale-up, plus the
+// required ServiceAccount, Role, and RoleBinding.
+func RenderCronHPAYAML(config CronHPAConfig) (string, error) {
+	tmpl, err := template.New("cronhpa").Parse(cronHPATemplate)
+	if err != nil {
+		return "", fmt.Errorf("parse cronhpa template: %w", err)
+	}
+
+	scaleDownCron, err := timeToCron(config.ScaleDownTime)
+	if err != nil {
+		return "", fmt.Errorf("invalid scale_down_time: %w", err)
+	}
+
+	scaleUpCron, err := timeToCron(config.ScaleUpTime)
+	if err != nil {
+		return "", fmt.Errorf("invalid scale_up_time: %w", err)
+	}
+
+	data := templateData{
+		Namespace:         config.Namespace,
+		Deployment:        config.Deployment,
+		ScaleDownCron:     scaleDownCron,
+		ScaleUpCron:       scaleUpCron,
+		MinReplicas:       config.MinReplicas,
+		MaxReplicas:       config.MaxReplicas,
+		NormalMinReplicas: config.MinReplicas * 2,
+		NormalMaxReplicas: config.MaxReplicas * 5,
+	}
+
+	if data.NormalMinReplicas < 2 {
+		data.NormalMinReplicas = 2
+	}
+	if data.NormalMaxReplicas < 10 {
+		data.NormalMaxReplicas = 10
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("execute cronhpa template: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+// timeToCron converts a "HH:MM" time string to a cron schedule expression.
+// Example: "22:00" -> "0 22 * * *".
+func timeToCron(timeStr string) (string, error) {
+	var hour, minute int
+
+	n, err := fmt.Sscanf(timeStr, "%d:%d", &hour, &minute)
+	if err != nil {
+		return "", fmt.Errorf("parse time %q: %w", timeStr, err)
+	}
+	if n != 2 {
+		return "", fmt.Errorf("parse time %q: expected HH:MM format", timeStr)
+	}
+	if hour < 0 || hour > 23 {
+		return "", fmt.Errorf("hour %d out of range [0, 23]", hour)
+	}
+	if minute < 0 || minute > 59 {
+		return "", fmt.Errorf("minute %d out of range [0, 59]", minute)
+	}
+
+	return fmt.Sprintf("%d %d * * *", minute, hour), nil
+}

--- a/backend/internal/analyzer/cronhpa_test.go
+++ b/backend/internal/analyzer/cronhpa_test.go
@@ -1,0 +1,220 @@
+package analyzer_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/akaitigo/infra-miru/backend/internal/analyzer"
+)
+
+func TestGenerateCronHPA(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		schedule        analyzer.ScheduleAnalysis
+		wantScaleDown   string
+		wantScaleUp     string
+		wantMinReplicas int32
+		wantMaxReplicas int32
+	}{
+		{
+			name: "uses low load hours for scale-down/up times",
+			schedule: analyzer.ScheduleAnalysis{
+				Namespace:    "prod",
+				Deployment:   "api",
+				LowLoadHours: []int{0, 1, 2, 3, 4, 5},
+			},
+			wantScaleDown:   "00:00",
+			wantScaleUp:     "06:00",
+			wantMinReplicas: 1,
+			wantMaxReplicas: 2,
+		},
+		{
+			name: "single low load hour",
+			schedule: analyzer.ScheduleAnalysis{
+				Namespace:    "staging",
+				Deployment:   "worker",
+				LowLoadHours: []int{3},
+			},
+			wantScaleDown:   "03:00",
+			wantScaleUp:     "04:00",
+			wantMinReplicas: 1,
+			wantMaxReplicas: 2,
+		},
+		{
+			name: "no low load hours uses defaults",
+			schedule: analyzer.ScheduleAnalysis{
+				Namespace:    "default",
+				Deployment:   "web",
+				LowLoadHours: nil,
+			},
+			wantScaleDown:   "22:00",
+			wantScaleUp:     "06:00",
+			wantMinReplicas: 1,
+			wantMaxReplicas: 2,
+		},
+		{
+			name: "low load hour at 23 wraps scale-up to 0",
+			schedule: analyzer.ScheduleAnalysis{
+				Namespace:    "default",
+				Deployment:   "batch",
+				LowLoadHours: []int{22, 23},
+			},
+			wantScaleDown:   "22:00",
+			wantScaleUp:     "00:00",
+			wantMinReplicas: 1,
+			wantMaxReplicas: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			config := analyzer.GenerateCronHPA(tt.schedule)
+
+			if config.Namespace != tt.schedule.Namespace {
+				t.Errorf("Namespace = %q, want %q", config.Namespace, tt.schedule.Namespace)
+			}
+			if config.Deployment != tt.schedule.Deployment {
+				t.Errorf("Deployment = %q, want %q", config.Deployment, tt.schedule.Deployment)
+			}
+			if config.ScaleDownTime != tt.wantScaleDown {
+				t.Errorf("ScaleDownTime = %q, want %q", config.ScaleDownTime, tt.wantScaleDown)
+			}
+			if config.ScaleUpTime != tt.wantScaleUp {
+				t.Errorf("ScaleUpTime = %q, want %q", config.ScaleUpTime, tt.wantScaleUp)
+			}
+			if config.MinReplicas != tt.wantMinReplicas {
+				t.Errorf("MinReplicas = %d, want %d", config.MinReplicas, tt.wantMinReplicas)
+			}
+			if config.MaxReplicas != tt.wantMaxReplicas {
+				t.Errorf("MaxReplicas = %d, want %d", config.MaxReplicas, tt.wantMaxReplicas)
+			}
+		})
+	}
+}
+
+func TestRenderCronHPAYAML(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		config   analyzer.CronHPAConfig
+		wantErr  bool
+		contains []string
+	}{
+		{
+			name: "valid config produces valid YAML",
+			config: analyzer.CronHPAConfig{
+				Namespace:     "prod",
+				Deployment:    "api",
+				ScaleDownTime: "22:00",
+				ScaleUpTime:   "06:00",
+				MinReplicas:   1,
+				MaxReplicas:   2,
+			},
+			wantErr: false,
+			contains: []string{
+				"kind: CronJob",
+				"api-scale-down",
+				"api-scale-up",
+				"namespace: prod",
+				"0 22 * * *",
+				"0 6 * * *",
+				"api-scaler",
+				"api-hpa-patcher",
+				"kind: ServiceAccount",
+				"kind: Role",
+				"kind: RoleBinding",
+			},
+		},
+		{
+			name: "different deployment name appears in YAML",
+			config: analyzer.CronHPAConfig{
+				Namespace:     "staging",
+				Deployment:    "worker",
+				ScaleDownTime: "00:00",
+				ScaleUpTime:   "06:00",
+				MinReplicas:   1,
+				MaxReplicas:   3,
+			},
+			wantErr: false,
+			contains: []string{
+				"worker-scale-down",
+				"worker-scale-up",
+				"namespace: staging",
+				"worker-scaler",
+			},
+		},
+		{
+			name: "invalid time format returns error",
+			config: analyzer.CronHPAConfig{
+				Namespace:     "default",
+				Deployment:    "test",
+				ScaleDownTime: "invalid",
+				ScaleUpTime:   "06:00",
+				MinReplicas:   1,
+				MaxReplicas:   2,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			yaml, err := analyzer.RenderCronHPAYAML(tt.config)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if yaml == "" {
+				t.Fatal("expected non-empty YAML")
+			}
+
+			for _, s := range tt.contains {
+				if !strings.Contains(yaml, s) {
+					t.Errorf("YAML does not contain %q", s)
+				}
+			}
+		})
+	}
+}
+
+func TestRenderCronHPAYAMLNormalReplicas(t *testing.T) {
+	t.Parallel()
+
+	config := analyzer.CronHPAConfig{
+		Namespace:     "prod",
+		Deployment:    "api",
+		ScaleDownTime: "22:00",
+		ScaleUpTime:   "06:00",
+		MinReplicas:   1,
+		MaxReplicas:   2,
+	}
+
+	yaml, err := analyzer.RenderCronHPAYAML(config)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// NormalMinReplicas = max(MinReplicas*2, 2) = 2
+	// NormalMaxReplicas = max(MaxReplicas*5, 10) = 10
+	if !strings.Contains(yaml, `"minReplicas":2`) {
+		t.Error("expected normal minReplicas of 2 in scale-up command")
+	}
+	if !strings.Contains(yaml, `"maxReplicas":10`) {
+		t.Error("expected normal maxReplicas of 10 in scale-up command")
+	}
+}

--- a/backend/internal/analyzer/schedule.go
+++ b/backend/internal/analyzer/schedule.go
@@ -1,0 +1,201 @@
+package analyzer
+
+import (
+	"sort"
+	"time"
+
+	"github.com/akaitigo/infra-miru/backend/internal/k8s"
+)
+
+// jst is the Asia/Tokyo timezone used for schedule analysis.
+var jst = time.FixedZone("JST", 9*60*60)
+
+// lowLoadThresholdRatio defines the ratio below the overall average that qualifies
+// as "low load". An hour is low-load if its average CPU usage is below
+// overallAverage * lowLoadThresholdRatio.
+const lowLoadThresholdRatio = 0.30
+
+// HourlyLoad holds aggregated resource usage for a specific hour of the day.
+type HourlyLoad struct {
+	Hour           int     `json:"hour"`
+	AvgCPUUsage    float64 `json:"avg_cpu_usage_millicores"`
+	AvgMemoryUsage float64 `json:"avg_memory_usage_bytes"`
+	SampleCount    int     `json:"sample_count"`
+}
+
+// ScheduleAnalysis holds time-based load analysis for a single Deployment.
+type ScheduleAnalysis struct {
+	Namespace        string       `json:"namespace"`
+	Deployment       string       `json:"deployment"`
+	HourlyLoads      []HourlyLoad `json:"hourly_loads"`
+	LowLoadHours     []int        `json:"low_load_hours"`
+	IsWeekendLowLoad bool         `json:"is_weekend_low_load"`
+}
+
+// hourAccum accumulates CPU and memory usage for a specific hour.
+type hourAccum struct {
+	cpuSum float64
+	memSum float64
+	count  int
+}
+
+// deployAccum accumulates schedule data for a single deployment.
+type deployAccum struct {
+	hours        [24]hourAccum
+	weekdayCPU   float64
+	weekdayCount int
+	weekendCPU   float64
+	weekendCount int
+}
+
+// deployKey uniquely identifies a deployment within a namespace.
+type deployKey struct {
+	namespace  string
+	deployment string
+}
+
+// AnalyzeSchedule groups Pods by Deployment and computes hourly load patterns.
+// It detects low-load hours (below 30% of overall average CPU) and weekend patterns.
+func (a *Analyzer) AnalyzeSchedule(pods []k8s.PodResource) []ScheduleAnalysis {
+	if len(pods) == 0 {
+		return []ScheduleAnalysis{}
+	}
+
+	// Preserve insertion order.
+	var keys []deployKey
+	index := make(map[deployKey]int)
+	var accums []deployAccum
+
+	for i := range pods {
+		pod := &pods[i]
+		if pod.Deployment == "" {
+			continue
+		}
+
+		key := deployKey{namespace: pod.Namespace, deployment: pod.Deployment}
+
+		idx, exists := index[key]
+		if !exists {
+			idx = len(accums)
+			index[key] = idx
+			keys = append(keys, key)
+			accums = append(accums, deployAccum{})
+		}
+
+		acc := &accums[idx]
+
+		jstTime := pod.CollectedAt.In(jst)
+		hour := jstTime.Hour()
+
+		acc.hours[hour].cpuSum += float64(pod.CPUUsage)
+		acc.hours[hour].memSum += float64(pod.MemoryUsage)
+		acc.hours[hour].count++
+
+		weekday := jstTime.Weekday()
+		if weekday == time.Saturday || weekday == time.Sunday {
+			acc.weekendCPU += float64(pod.CPUUsage)
+			acc.weekendCount++
+		} else {
+			acc.weekdayCPU += float64(pod.CPUUsage)
+			acc.weekdayCount++
+		}
+	}
+
+	results := make([]ScheduleAnalysis, 0, len(keys))
+
+	for _, key := range keys {
+		idx := index[key]
+		acc := &accums[idx]
+
+		hourlyLoads := buildHourlyLoads(&acc.hours)
+		overallAvg := overallAverageCPU(hourlyLoads)
+		lowLoadHours := detectLowLoadHours(hourlyLoads, overallAvg)
+		weekendLow := isWeekendLowLoad(acc)
+
+		results = append(results, ScheduleAnalysis{
+			Namespace:        key.namespace,
+			Deployment:       key.deployment,
+			HourlyLoads:      hourlyLoads,
+			LowLoadHours:     lowLoadHours,
+			IsWeekendLowLoad: weekendLow,
+		})
+	}
+
+	return results
+}
+
+// buildHourlyLoads converts the 24-hour accumulator array into a slice of HourlyLoad.
+// Only hours with at least one sample are included.
+func buildHourlyLoads(hours *[24]hourAccum) []HourlyLoad {
+	loads := make([]HourlyLoad, 0, 24)
+
+	for h := 0; h < 24; h++ {
+		if hours[h].count == 0 {
+			continue
+		}
+		loads = append(loads, HourlyLoad{
+			Hour:           h,
+			AvgCPUUsage:    hours[h].cpuSum / float64(hours[h].count),
+			AvgMemoryUsage: hours[h].memSum / float64(hours[h].count),
+			SampleCount:    hours[h].count,
+		})
+	}
+
+	return loads
+}
+
+// overallAverageCPU computes the average CPU usage across all hourly loads,
+// weighted by sample count.
+func overallAverageCPU(loads []HourlyLoad) float64 {
+	if len(loads) == 0 {
+		return 0
+	}
+
+	totalCPU := 0.0
+	totalSamples := 0
+
+	for i := range loads {
+		totalCPU += loads[i].AvgCPUUsage * float64(loads[i].SampleCount)
+		totalSamples += loads[i].SampleCount
+	}
+
+	if totalSamples == 0 {
+		return 0
+	}
+
+	return totalCPU / float64(totalSamples)
+}
+
+// detectLowLoadHours returns hours where the average CPU usage is below the
+// threshold (overallAvg * lowLoadThresholdRatio). Results are sorted ascending.
+func detectLowLoadHours(loads []HourlyLoad, overallAvg float64) []int {
+	threshold := overallAvg * lowLoadThresholdRatio
+
+	var hours []int
+	for i := range loads {
+		if loads[i].AvgCPUUsage < threshold {
+			hours = append(hours, loads[i].Hour)
+		}
+	}
+
+	sort.Ints(hours)
+
+	return hours
+}
+
+// isWeekendLowLoad determines whether the weekend average CPU is significantly
+// lower than the weekday average. It uses the same 30% threshold ratio.
+func isWeekendLowLoad(acc *deployAccum) bool {
+	if acc.weekdayCount == 0 || acc.weekendCount == 0 {
+		return false
+	}
+
+	weekdayAvg := acc.weekdayCPU / float64(acc.weekdayCount)
+	weekendAvg := acc.weekendCPU / float64(acc.weekendCount)
+
+	if weekdayAvg == 0 {
+		return false
+	}
+
+	return weekendAvg < weekdayAvg*lowLoadThresholdRatio
+}

--- a/backend/internal/analyzer/schedule_test.go
+++ b/backend/internal/analyzer/schedule_test.go
@@ -1,0 +1,306 @@
+package analyzer_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/akaitigo/infra-miru/backend/internal/analyzer"
+	"github.com/akaitigo/infra-miru/backend/internal/k8s"
+)
+
+// jst is Asia/Tokyo timezone for test data construction.
+var jst = time.FixedZone("JST", 9*60*60)
+
+func TestAnalyzeSchedule(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		pods              []k8s.PodResource
+		wantCount         int
+		checkDeployment   string
+		checkLowLoadHours []int
+		checkWeekendLow   bool
+	}{
+		{
+			name:      "empty pods returns empty result",
+			pods:      []k8s.PodResource{},
+			wantCount: 0,
+		},
+		{
+			name: "pods without deployment are skipped",
+			pods: []k8s.PodResource{
+				{
+					Namespace:   "default",
+					PodName:     "orphan-pod",
+					Deployment:  "",
+					CPUUsage:    100,
+					MemoryUsage: 256 * 1024 * 1024,
+					CollectedAt: time.Date(2026, 4, 1, 1, 0, 0, 0, jst),
+				},
+			},
+			wantCount: 0,
+		},
+		{
+			name: "nighttime low load detection",
+			pods: nighttimeLowLoadPods(),
+			// Daytime pods at hour 10,14 with CPU 1000; nighttime at hour 2 with CPU 10.
+			// Overall avg ~670. Threshold = 670*0.30 = ~201. Hour 2 (cpu=10) is below.
+			wantCount:         1,
+			checkDeployment:   "api",
+			checkLowLoadHours: []int{2},
+			checkWeekendLow:   false,
+		},
+		{
+			name:              "weekend low load detection",
+			pods:              weekendLowLoadPods(),
+			wantCount:         1,
+			checkDeployment:   "api",
+			checkLowLoadHours: nil, // all hours have similar load
+			checkWeekendLow:   true,
+		},
+		{
+			name: "threshold boundary - exactly at 30% is not low load",
+			pods: thresholdBoundaryPods(),
+			// Two hours: hour 10 with CPU 1000, hour 2 with CPU 300.
+			// Overall avg = (1000+300)/2 = 650. Threshold = 650*0.30 = 195.
+			// Hour 2 (300) > 195, so not low-load.
+			wantCount:         1,
+			checkDeployment:   "api",
+			checkLowLoadHours: nil,
+			checkWeekendLow:   false,
+		},
+		{
+			name: "multiple deployments analyzed separately",
+			pods: multiDeploymentPods(),
+			// Two deployments: "api" and "worker"
+			wantCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := analyzer.NewAnalyzer()
+			results := a.AnalyzeSchedule(tt.pods)
+
+			if len(results) != tt.wantCount {
+				t.Fatalf("got %d schedule analyses, want %d", len(results), tt.wantCount)
+			}
+
+			if tt.checkDeployment == "" {
+				return
+			}
+
+			var found *analyzer.ScheduleAnalysis
+			for i := range results {
+				if results[i].Deployment == tt.checkDeployment {
+					found = &results[i]
+					break
+				}
+			}
+
+			if found == nil {
+				t.Fatalf("deployment %q not found in results", tt.checkDeployment)
+			}
+
+			if tt.checkLowLoadHours != nil {
+				if !intSliceEqual(found.LowLoadHours, tt.checkLowLoadHours) {
+					t.Errorf("LowLoadHours = %v, want %v", found.LowLoadHours, tt.checkLowLoadHours)
+				}
+			} else {
+				if len(found.LowLoadHours) != 0 {
+					t.Errorf("LowLoadHours = %v, want empty", found.LowLoadHours)
+				}
+			}
+
+			if found.IsWeekendLowLoad != tt.checkWeekendLow {
+				t.Errorf("IsWeekendLowLoad = %v, want %v", found.IsWeekendLowLoad, tt.checkWeekendLow)
+			}
+		})
+	}
+}
+
+func TestAnalyzeScheduleHourlyLoads(t *testing.T) {
+	t.Parallel()
+
+	// Create pods at two distinct hours.
+	pods := []k8s.PodResource{
+		{
+			Namespace:   "default",
+			PodName:     "api-pod-1",
+			Deployment:  "api",
+			CPUUsage:    100,
+			MemoryUsage: 256 * 1024 * 1024,
+			CollectedAt: time.Date(2026, 4, 1, 1, 0, 0, 0, jst), // hour 10 JST
+		},
+		{
+			Namespace:   "default",
+			PodName:     "api-pod-2",
+			Deployment:  "api",
+			CPUUsage:    200,
+			MemoryUsage: 512 * 1024 * 1024,
+			CollectedAt: time.Date(2026, 4, 1, 1, 0, 0, 0, jst), // same hour
+		},
+	}
+
+	a := analyzer.NewAnalyzer()
+	results := a.AnalyzeSchedule(pods)
+
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+
+	if len(results[0].HourlyLoads) != 1 {
+		t.Fatalf("got %d hourly loads, want 1", len(results[0].HourlyLoads))
+	}
+
+	hl := results[0].HourlyLoads[0]
+	if hl.SampleCount != 2 {
+		t.Errorf("SampleCount = %d, want 2", hl.SampleCount)
+	}
+
+	// Average CPU: (100+200)/2 = 150
+	wantAvgCPU := 150.0
+	if hl.AvgCPUUsage != wantAvgCPU {
+		t.Errorf("AvgCPUUsage = %f, want %f", hl.AvgCPUUsage, wantAvgCPU)
+	}
+}
+
+// nighttimeLowLoadPods creates pods with high daytime and low nighttime usage.
+func nighttimeLowLoadPods() []k8s.PodResource {
+	// Tuesday 2026-03-31
+	day := time.Date(2026, 3, 31, 0, 0, 0, 0, jst)
+
+	return []k8s.PodResource{
+		{
+			Namespace:   "default",
+			PodName:     "api-pod-1",
+			Deployment:  "api",
+			CPUUsage:    1000,
+			MemoryUsage: 512 * 1024 * 1024,
+			CollectedAt: day.Add(10 * time.Hour), // 10:00 JST
+		},
+		{
+			Namespace:   "default",
+			PodName:     "api-pod-2",
+			Deployment:  "api",
+			CPUUsage:    1000,
+			MemoryUsage: 512 * 1024 * 1024,
+			CollectedAt: day.Add(14 * time.Hour), // 14:00 JST
+		},
+		{
+			Namespace:   "default",
+			PodName:     "api-pod-3",
+			Deployment:  "api",
+			CPUUsage:    10, // very low
+			MemoryUsage: 32 * 1024 * 1024,
+			CollectedAt: day.Add(2 * time.Hour), // 02:00 JST (nighttime)
+		},
+	}
+}
+
+// weekendLowLoadPods creates pods with high weekday and very low weekend usage.
+func weekendLowLoadPods() []k8s.PodResource {
+	// Monday 2026-03-30
+	weekday := time.Date(2026, 3, 30, 10, 0, 0, 0, jst)
+	// Saturday 2026-04-04
+	weekend := time.Date(2026, 4, 4, 10, 0, 0, 0, jst)
+
+	return []k8s.PodResource{
+		{
+			Namespace:   "default",
+			PodName:     "api-pod-1",
+			Deployment:  "api",
+			CPUUsage:    1000,
+			MemoryUsage: 512 * 1024 * 1024,
+			CollectedAt: weekday,
+		},
+		{
+			Namespace:   "default",
+			PodName:     "api-pod-2",
+			Deployment:  "api",
+			CPUUsage:    900,
+			MemoryUsage: 480 * 1024 * 1024,
+			CollectedAt: weekday.Add(time.Hour),
+		},
+		{
+			Namespace:   "default",
+			PodName:     "api-pod-3",
+			Deployment:  "api",
+			CPUUsage:    50, // much lower than weekday
+			MemoryUsage: 32 * 1024 * 1024,
+			CollectedAt: weekend,
+		},
+		{
+			Namespace:   "default",
+			PodName:     "api-pod-4",
+			Deployment:  "api",
+			CPUUsage:    40,
+			MemoryUsage: 28 * 1024 * 1024,
+			CollectedAt: weekend.Add(time.Hour),
+		},
+	}
+}
+
+// thresholdBoundaryPods creates pods at exactly the boundary of the low load threshold.
+func thresholdBoundaryPods() []k8s.PodResource {
+	day := time.Date(2026, 3, 31, 0, 0, 0, 0, jst) // Tuesday
+
+	return []k8s.PodResource{
+		{
+			Namespace:   "default",
+			PodName:     "api-pod-1",
+			Deployment:  "api",
+			CPUUsage:    1000,
+			MemoryUsage: 512 * 1024 * 1024,
+			CollectedAt: day.Add(10 * time.Hour), // 10:00 JST
+		},
+		{
+			Namespace:   "default",
+			PodName:     "api-pod-2",
+			Deployment:  "api",
+			CPUUsage:    300, // 300 > 650*0.30=195, so not low-load
+			MemoryUsage: 128 * 1024 * 1024,
+			CollectedAt: day.Add(2 * time.Hour), // 02:00 JST
+		},
+	}
+}
+
+// multiDeploymentPods creates pods from two different deployments.
+func multiDeploymentPods() []k8s.PodResource {
+	day := time.Date(2026, 3, 31, 10, 0, 0, 0, jst)
+
+	return []k8s.PodResource{
+		{
+			Namespace:   "default",
+			PodName:     "api-pod-1",
+			Deployment:  "api",
+			CPUUsage:    500,
+			MemoryUsage: 256 * 1024 * 1024,
+			CollectedAt: day,
+		},
+		{
+			Namespace:   "default",
+			PodName:     "worker-pod-1",
+			Deployment:  "worker",
+			CPUUsage:    300,
+			MemoryUsage: 128 * 1024 * 1024,
+			CollectedAt: day,
+		},
+	}
+}
+
+// intSliceEqual checks if two int slices are identical.
+func intSliceEqual(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -49,6 +49,8 @@ func NewRouter(deps *RouterDeps) *chi.Mux {
 		if deps != nil {
 			r.Get("/resources", ResourceHandler(deps.PodLister, deps.Analyzer))
 			r.Get("/recommendations", RecommendationHandler(deps.PodLister, deps.Analyzer, deps.Calculator))
+			r.Get("/schedules", ScheduleHandler(deps.PodLister, deps.Analyzer))
+			r.Get("/cronhpa/{deployment}", CronHPAHandler(deps.PodLister, deps.Analyzer))
 		}
 	})
 

--- a/backend/internal/api/schedule_handler.go
+++ b/backend/internal/api/schedule_handler.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/akaitigo/infra-miru/backend/internal/analyzer"
+	"github.com/akaitigo/infra-miru/backend/internal/k8s"
+)
+
+// ScheduleResponse is the JSON body for GET /api/v1/schedules.
+type ScheduleResponse struct {
+	Schedules []analyzer.ScheduleAnalysis `json:"schedules"`
+}
+
+// CronHPAResponse is the JSON body for GET /api/v1/cronhpa/{deployment}.
+type CronHPAResponse struct {
+	YAML   string                 `json:"yaml"`
+	Config analyzer.CronHPAConfig `json:"config"`
+}
+
+// ScheduleHandler returns an HTTP handler that analyzes hourly load patterns
+// for deployments.
+// Query parameters:
+//   - namespace: filter by Kubernetes namespace
+//   - deployment: filter by Deployment name
+func ScheduleHandler(lister PodLister, a *analyzer.Analyzer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		opts := k8s.ListOptions{
+			Namespace:  r.URL.Query().Get("namespace"),
+			Deployment: r.URL.Query().Get("deployment"),
+		}
+
+		pods, err := lister.ListPods(r.Context(), opts)
+		if err != nil {
+			JSONError(w, http.StatusInternalServerError, "failed to list pods", "LIST_PODS_ERROR")
+			return
+		}
+
+		schedules := a.AnalyzeSchedule(pods)
+
+		JSON(w, http.StatusOK, ScheduleResponse{
+			Schedules: schedules,
+		})
+	}
+}
+
+// CronHPAHandler returns an HTTP handler that generates a CronHPA YAML template
+// for a specific deployment.
+// URL parameter:
+//   - deployment: the deployment name (chi URL param)
+//
+// Query parameters:
+//   - namespace: Kubernetes namespace (required)
+func CronHPAHandler(lister PodLister, a *analyzer.Analyzer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		deployment := chi.URLParam(r, "deployment")
+		if deployment == "" {
+			JSONError(w, http.StatusBadRequest, "deployment is required", "MISSING_DEPLOYMENT")
+			return
+		}
+
+		namespace := r.URL.Query().Get("namespace")
+		if namespace == "" {
+			JSONError(w, http.StatusBadRequest, "namespace query parameter is required", "MISSING_NAMESPACE")
+			return
+		}
+
+		opts := k8s.ListOptions{
+			Namespace:  namespace,
+			Deployment: deployment,
+		}
+
+		pods, err := lister.ListPods(r.Context(), opts)
+		if err != nil {
+			JSONError(w, http.StatusInternalServerError, "failed to list pods", "LIST_PODS_ERROR")
+			return
+		}
+
+		schedules := a.AnalyzeSchedule(pods)
+
+		// Find the schedule for the requested deployment.
+		var target *analyzer.ScheduleAnalysis
+		for i := range schedules {
+			if schedules[i].Deployment == deployment && schedules[i].Namespace == namespace {
+				target = &schedules[i]
+				break
+			}
+		}
+
+		if target == nil {
+			// No data found; generate a default config.
+			target = &analyzer.ScheduleAnalysis{
+				Namespace:  namespace,
+				Deployment: deployment,
+			}
+		}
+
+		config := analyzer.GenerateCronHPA(*target)
+
+		yaml, err := analyzer.RenderCronHPAYAML(config)
+		if err != nil {
+			JSONError(w, http.StatusInternalServerError, "failed to render CronHPA YAML", "RENDER_YAML_ERROR")
+			return
+		}
+
+		JSON(w, http.StatusOK, CronHPAResponse{
+			YAML:   yaml,
+			Config: config,
+		})
+	}
+}

--- a/backend/internal/api/schedule_handler_test.go
+++ b/backend/internal/api/schedule_handler_test.go
@@ -1,0 +1,361 @@
+package api_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/akaitigo/infra-miru/backend/internal/analyzer"
+	"github.com/akaitigo/infra-miru/backend/internal/api"
+	"github.com/akaitigo/infra-miru/backend/internal/cost"
+	"github.com/akaitigo/infra-miru/backend/internal/k8s"
+)
+
+// jst is Asia/Tokyo timezone for test data construction.
+var jst = time.FixedZone("JST", 9*60*60)
+
+func TestScheduleHandler(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		lister     *fakePodLister
+		query      string
+		wantStatus int
+		check      func(t *testing.T, body []byte)
+	}{
+		{
+			name: "returns schedule analyses for pods",
+			lister: &fakePodLister{
+				pods: []k8s.PodResource{
+					{
+						Namespace:   "default",
+						PodName:     "api-pod-1",
+						Deployment:  "api",
+						CPUUsage:    500,
+						MemoryUsage: 256 * 1024 * 1024,
+						CollectedAt: time.Date(2026, 4, 1, 1, 0, 0, 0, jst), // 10:00 JST
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+			check: func(t *testing.T, body []byte) {
+				t.Helper()
+				var resp api.ScheduleResponse
+				if err := json.Unmarshal(body, &resp); err != nil {
+					t.Fatalf("failed to unmarshal response: %v", err)
+				}
+				if len(resp.Schedules) != 1 {
+					t.Fatalf("got %d schedules, want 1", len(resp.Schedules))
+				}
+				if resp.Schedules[0].Deployment != "api" {
+					t.Errorf("Deployment = %q, want %q", resp.Schedules[0].Deployment, "api")
+				}
+			},
+		},
+		{
+			name: "empty pods returns empty schedules",
+			lister: &fakePodLister{
+				pods: []k8s.PodResource{},
+			},
+			wantStatus: http.StatusOK,
+			check: func(t *testing.T, body []byte) {
+				t.Helper()
+				var resp api.ScheduleResponse
+				if err := json.Unmarshal(body, &resp); err != nil {
+					t.Fatalf("failed to unmarshal response: %v", err)
+				}
+				if len(resp.Schedules) != 0 {
+					t.Errorf("got %d schedules, want 0", len(resp.Schedules))
+				}
+			},
+		},
+		{
+			name: "lister error returns 500",
+			lister: &fakePodLister{
+				err: fmt.Errorf("connection refused"),
+			},
+			wantStatus: http.StatusInternalServerError,
+			check: func(t *testing.T, body []byte) {
+				t.Helper()
+				var resp api.ErrorResponse
+				if err := json.Unmarshal(body, &resp); err != nil {
+					t.Fatalf("failed to unmarshal error response: %v", err)
+				}
+				if resp.Code != "LIST_PODS_ERROR" {
+					t.Errorf("error code = %q, want %q", resp.Code, "LIST_PODS_ERROR")
+				}
+			},
+		},
+		{
+			name: "query parameters are accepted",
+			lister: &fakePodLister{
+				pods: []k8s.PodResource{},
+			},
+			query:      "?namespace=prod&deployment=api",
+			wantStatus: http.StatusOK,
+			check: func(t *testing.T, body []byte) {
+				t.Helper()
+				var resp api.ScheduleResponse
+				if err := json.Unmarshal(body, &resp); err != nil {
+					t.Fatalf("failed to unmarshal response: %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := analyzer.NewAnalyzer()
+			handler := api.ScheduleHandler(tt.lister, a)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/schedules"+tt.query, nil)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+
+			contentType := rec.Header().Get("Content-Type")
+			if contentType != "application/json" {
+				t.Errorf("Content-Type = %q, want %q", contentType, "application/json")
+			}
+
+			if tt.check != nil {
+				tt.check(t, rec.Body.Bytes())
+			}
+		})
+	}
+}
+
+func TestCronHPAHandler(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		lister     *fakePodLister
+		path       string
+		wantStatus int
+		check      func(t *testing.T, body []byte)
+	}{
+		{
+			name: "generates CronHPA for deployment with data",
+			lister: &fakePodLister{
+				pods: []k8s.PodResource{
+					{
+						Namespace:   "prod",
+						PodName:     "api-pod-1",
+						Deployment:  "api",
+						CPUUsage:    500,
+						MemoryUsage: 256 * 1024 * 1024,
+						CollectedAt: time.Date(2026, 4, 1, 1, 0, 0, 0, jst),
+					},
+				},
+			},
+			path:       "/api/v1/cronhpa/api?namespace=prod",
+			wantStatus: http.StatusOK,
+			check: func(t *testing.T, body []byte) {
+				t.Helper()
+				var resp api.CronHPAResponse
+				if err := json.Unmarshal(body, &resp); err != nil {
+					t.Fatalf("failed to unmarshal response: %v", err)
+				}
+				if resp.YAML == "" {
+					t.Error("expected non-empty YAML")
+				}
+				if resp.Config.Namespace != "prod" {
+					t.Errorf("Config.Namespace = %q, want %q", resp.Config.Namespace, "prod")
+				}
+				if resp.Config.Deployment != "api" {
+					t.Errorf("Config.Deployment = %q, want %q", resp.Config.Deployment, "api")
+				}
+			},
+		},
+		{
+			name: "generates default CronHPA when no matching pods",
+			lister: &fakePodLister{
+				pods: []k8s.PodResource{},
+			},
+			path:       "/api/v1/cronhpa/web?namespace=staging",
+			wantStatus: http.StatusOK,
+			check: func(t *testing.T, body []byte) {
+				t.Helper()
+				var resp api.CronHPAResponse
+				if err := json.Unmarshal(body, &resp); err != nil {
+					t.Fatalf("failed to unmarshal response: %v", err)
+				}
+				if resp.Config.ScaleDownTime != "22:00" {
+					t.Errorf("ScaleDownTime = %q, want default %q", resp.Config.ScaleDownTime, "22:00")
+				}
+				if resp.Config.ScaleUpTime != "06:00" {
+					t.Errorf("ScaleUpTime = %q, want default %q", resp.Config.ScaleUpTime, "06:00")
+				}
+			},
+		},
+		{
+			name: "missing namespace returns 400",
+			lister: &fakePodLister{
+				pods: []k8s.PodResource{},
+			},
+			path:       "/api/v1/cronhpa/api",
+			wantStatus: http.StatusBadRequest,
+			check: func(t *testing.T, body []byte) {
+				t.Helper()
+				var resp api.ErrorResponse
+				if err := json.Unmarshal(body, &resp); err != nil {
+					t.Fatalf("failed to unmarshal error response: %v", err)
+				}
+				if resp.Code != "MISSING_NAMESPACE" {
+					t.Errorf("error code = %q, want %q", resp.Code, "MISSING_NAMESPACE")
+				}
+			},
+		},
+		{
+			name: "lister error returns 500",
+			lister: &fakePodLister{
+				err: fmt.Errorf("cluster unreachable"),
+			},
+			path:       "/api/v1/cronhpa/api?namespace=prod",
+			wantStatus: http.StatusInternalServerError,
+			check: func(t *testing.T, body []byte) {
+				t.Helper()
+				var resp api.ErrorResponse
+				if err := json.Unmarshal(body, &resp); err != nil {
+					t.Fatalf("failed to unmarshal error response: %v", err)
+				}
+				if resp.Code != "LIST_PODS_ERROR" {
+					t.Errorf("error code = %q, want %q", resp.Code, "LIST_PODS_ERROR")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			router := api.NewRouter(&api.RouterDeps{
+				PodLister:  tt.lister,
+				Analyzer:   analyzer.NewAnalyzer(),
+				Calculator: cost.NewCalculator(),
+			})
+
+			srv := httptest.NewServer(router)
+			defer srv.Close()
+
+			resp, err := http.Get(srv.URL + tt.path)
+			if err != nil {
+				t.Fatalf("failed to GET %s: %v", tt.path, err)
+			}
+			defer func() {
+				if closeErr := resp.Body.Close(); closeErr != nil {
+					t.Logf("failed to close response body: %v", closeErr)
+				}
+			}()
+
+			if resp.StatusCode != tt.wantStatus {
+				t.Errorf("status = %d, want %d", resp.StatusCode, tt.wantStatus)
+			}
+
+			contentType := resp.Header.Get("Content-Type")
+			if contentType != "application/json" {
+				t.Errorf("Content-Type = %q, want %q", contentType, "application/json")
+			}
+
+			var body []byte
+			body, err = readBody(resp)
+			if err != nil {
+				t.Fatalf("failed to read response body: %v", err)
+			}
+
+			if tt.check != nil {
+				tt.check(t, body)
+			}
+		})
+	}
+}
+
+func TestScheduleHandlerViaRouter(t *testing.T) {
+	t.Parallel()
+
+	lister := &fakePodLister{
+		pods: []k8s.PodResource{
+			{
+				Namespace:   "default",
+				PodName:     "api-pod-1",
+				Deployment:  "api",
+				CPUUsage:    500,
+				MemoryUsage: 256 * 1024 * 1024,
+				CollectedAt: time.Date(2026, 4, 1, 1, 0, 0, 0, jst),
+			},
+		},
+	}
+
+	router := api.NewRouter(&api.RouterDeps{
+		PodLister:  lister,
+		Analyzer:   analyzer.NewAnalyzer(),
+		Calculator: cost.NewCalculator(),
+	})
+
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/schedules")
+	if err != nil {
+		t.Fatalf("failed to GET /api/v1/schedules: %v", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Logf("failed to close response body: %v", closeErr)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var body api.ScheduleResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(body.Schedules) != 1 {
+		t.Errorf("got %d schedules, want 1", len(body.Schedules))
+	}
+}
+
+// readBody reads all bytes from an HTTP response body.
+func readBody(resp *http.Response) ([]byte, error) {
+	var buf []byte
+	buf, err := readAllFrom(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+// readAllFrom is a small helper to read all bytes from an io.Reader.
+func readAllFrom(r interface{ Read([]byte) (int, error) }) ([]byte, error) {
+	var result []byte
+	buf := make([]byte, 4096)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			result = append(result, buf[:n]...)
+		}
+		if err != nil {
+			if err.Error() == "EOF" {
+				break
+			}
+			return nil, err
+		}
+	}
+	return result, nil
+}


### PR DESCRIPTION
## Summary
- PodResourceの収集時刻(CollectedAt)からJST時間帯別の平均CPU/Memory使用量を算出し、全体平均の30%未満の時間帯を低負荷として検出する`AnalyzeSchedule`を実装
- 検出した低負荷時間帯に基づいてCronJob + kubectl patchパターンのCronHPA YAMLテンプレートを生成する`GenerateCronHPA`/`RenderCronHPAYAML`を実装
- 新APIエンドポイント `GET /api/v1/schedules`（時間帯別負荷パターン）と `GET /api/v1/cronhpa/{deployment}`（CronHPAテンプレート取得）を追加

## Changes
- `backend/internal/analyzer/schedule.go` — 時間帯分析ロジック（HourlyLoad, ScheduleAnalysis型、夜間/休日低負荷検出）
- `backend/internal/analyzer/cronhpa.go` — CronHPA設定生成とYAMLテンプレートレンダリング（CronJob, ServiceAccount, Role, RoleBinding含む）
- `backend/internal/api/schedule_handler.go` — ScheduleHandler, CronHPAHandler
- `backend/internal/api/router.go` — 新ルート2件追加
- テスト6ファイル（analyzer: schedule_test.go, cronhpa_test.go / api: schedule_handler_test.go）

## Test plan
- [x] `go test -v -race ./...` 全パス
- [x] `golangci-lint run ./...` 0 issues
- [x] 夜間低負荷検出テスト
- [x] 休日低負荷検出テスト
- [x] 閾値境界テスト（30%ちょうどは低負荷でないこと）
- [x] 空データテスト
- [x] YAML生成テスト（必須フィールド含有確認）
- [x] ハンドラ正常系/エラー系テスト
- [x] namespaceパラメータ必須バリデーションテスト

Closes #7