### PR TITLE
feat: E2E結合テストとCI安定化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,10 @@ jobs:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
 
-      - name: Install tools
-        run: |
-          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
-          go install mvdan.cc/gofumpt@latest
-
-      - name: Lint
-        run: cd backend && golangci-lint run ./...
+      - uses: golangci/golangci-lint-action@v7
+        with:
+          version: latest
+          working-directory: backend
 
       - name: Test
         run: cd backend && go test -v -race -count=1 ./...

--- a/backend/internal/api/integration_test.go
+++ b/backend/internal/api/integration_test.go
@@ -1,0 +1,445 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/akaitigo/infra-miru/backend/internal/analyzer"
+	"github.com/akaitigo/infra-miru/backend/internal/api"
+	"github.com/akaitigo/infra-miru/backend/internal/cost"
+	"github.com/akaitigo/infra-miru/backend/internal/k8s"
+)
+
+// httpResult holds the result of an HTTP request with the body already read and
+// closed. This avoids bodyclose linter warnings by ensuring the response body
+// is always consumed and closed inside doGet.
+type httpResult struct {
+	StatusCode  int
+	ContentType string
+	Body        []byte
+}
+
+// integrationServer creates an httptest.Server with all routes registered using
+// the given fakePodLister. The caller must call srv.Close() when done.
+func integrationServer(lister *fakePodLister) *httptest.Server {
+	router := api.NewRouter(&api.RouterDeps{
+		PodLister:  lister,
+		Analyzer:   analyzer.NewAnalyzer(),
+		Calculator: cost.NewCalculator(),
+	})
+	return httptest.NewServer(router)
+}
+
+// overProvisionedPods returns a slice of pods where CPU/memory usage is much
+// lower than requests, causing them to be flagged as over-provisioned.
+func overProvisionedPods() []k8s.PodResource {
+	jst := time.FixedZone("JST", 9*60*60)
+	return []k8s.PodResource{
+		{
+			Namespace:     "default",
+			PodName:       "web-pod-1",
+			Deployment:    "web",
+			CPURequest:    1000,
+			CPUUsage:      100,
+			MemoryRequest: 1024 * 1024 * 1024,
+			MemoryUsage:   64 * 1024 * 1024,
+			CollectedAt:   time.Date(2026, 4, 1, 1, 0, 0, 0, jst),
+		},
+		{
+			Namespace:     "default",
+			PodName:       "web-pod-2",
+			Deployment:    "web",
+			CPURequest:    1000,
+			CPUUsage:      120,
+			MemoryRequest: 1024 * 1024 * 1024,
+			MemoryUsage:   80 * 1024 * 1024,
+			CollectedAt:   time.Date(2026, 4, 1, 2, 0, 0, 0, jst),
+		},
+	}
+}
+
+// wellProvisionedPods returns a slice of pods where usage is close to requests.
+func wellProvisionedPods() []k8s.PodResource {
+	jst := time.FixedZone("JST", 9*60*60)
+	return []k8s.PodResource{
+		{
+			Namespace:     "production",
+			PodName:       "api-pod-1",
+			Deployment:    "api",
+			CPURequest:    100,
+			CPUUsage:      80,
+			MemoryRequest: 256 * 1024 * 1024,
+			MemoryUsage:   200 * 1024 * 1024,
+			CollectedAt:   time.Date(2026, 4, 1, 10, 0, 0, 0, jst),
+		},
+	}
+}
+
+// doGet performs a GET request against the given URL with a background context.
+// It reads and closes the response body, returning the result in an httpResult.
+func doGet(t *testing.T, url string) httpResult {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s failed: %v", url, err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			t.Logf("failed to close response body: %v", closeErr)
+		}
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+
+	return httpResult{
+		StatusCode:  resp.StatusCode,
+		ContentType: resp.Header.Get("Content-Type"),
+		Body:        body,
+	}
+}
+
+func TestIntegration_Health(t *testing.T) {
+	t.Parallel()
+
+	srv := integrationServer(&fakePodLister{pods: []k8s.PodResource{}})
+	defer srv.Close()
+
+	result := doGet(t, srv.URL+"/api/v1/health")
+
+	if result.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want %d", result.StatusCode, http.StatusOK)
+	}
+
+	if result.ContentType != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", result.ContentType, "application/json")
+	}
+
+	var health api.HealthResponse
+	if err := json.Unmarshal(result.Body, &health); err != nil {
+		t.Fatalf("failed to unmarshal health response: %v", err)
+	}
+	if health.Status != "ok" {
+		t.Errorf("health.Status = %q, want %q", health.Status, "ok")
+	}
+}
+
+func TestIntegration_Resources(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		lister     *fakePodLister
+		path       string
+		wantStatus int
+		check      func(t *testing.T, body []byte)
+	}{
+		{
+			name:       "returns pods and deployments",
+			lister:     &fakePodLister{pods: overProvisionedPods()},
+			path:       "/api/v1/resources",
+			wantStatus: http.StatusOK,
+			check: func(t *testing.T, body []byte) {
+				t.Helper()
+				var resp api.ResourceResponse
+				if err := json.Unmarshal(body, &resp); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if len(resp.Pods) != 2 {
+					t.Errorf("got %d pods, want 2", len(resp.Pods))
+				}
+				if len(resp.Deployments) != 1 {
+					t.Errorf("got %d deployments, want 1", len(resp.Deployments))
+				}
+				if resp.Deployments[0].Deployment != "web" {
+					t.Errorf("Deployment = %q, want %q", resp.Deployments[0].Deployment, "web")
+				}
+			},
+		},
+		{
+			name:       "namespace filter is accepted",
+			lister:     &fakePodLister{pods: overProvisionedPods()},
+			path:       "/api/v1/resources?namespace=default",
+			wantStatus: http.StatusOK,
+			check: func(t *testing.T, body []byte) {
+				t.Helper()
+				var resp api.ResourceResponse
+				if err := json.Unmarshal(body, &resp); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				// fakePodLister ignores filters, so we just verify the endpoint
+				// processes the parameter without error.
+				if len(resp.Pods) == 0 {
+					t.Error("expected pods in response")
+				}
+			},
+		},
+		{
+			name:       "empty cluster returns empty arrays",
+			lister:     &fakePodLister{pods: []k8s.PodResource{}},
+			path:       "/api/v1/resources",
+			wantStatus: http.StatusOK,
+			check: func(t *testing.T, body []byte) {
+				t.Helper()
+				var resp api.ResourceResponse
+				if err := json.Unmarshal(body, &resp); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if len(resp.Pods) != 0 {
+					t.Errorf("got %d pods, want 0", len(resp.Pods))
+				}
+				if len(resp.Deployments) != 0 {
+					t.Errorf("got %d deployments, want 0", len(resp.Deployments))
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			srv := integrationServer(tt.lister)
+			defer srv.Close()
+
+			result := doGet(t, srv.URL+tt.path)
+
+			if result.StatusCode != tt.wantStatus {
+				t.Errorf("status = %d, want %d", result.StatusCode, tt.wantStatus)
+			}
+
+			if result.ContentType != "application/json" {
+				t.Errorf("Content-Type = %q, want %q", result.ContentType, "application/json")
+			}
+
+			if tt.check != nil {
+				tt.check(t, result.Body)
+			}
+		})
+	}
+}
+
+func TestIntegration_Recommendations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		lister     *fakePodLister
+		wantStatus int
+		check      func(t *testing.T, body []byte)
+	}{
+		{
+			name:       "over-provisioned pods generate recommendations",
+			lister:     &fakePodLister{pods: overProvisionedPods()},
+			wantStatus: http.StatusOK,
+			check: func(t *testing.T, body []byte) {
+				t.Helper()
+				var resp api.RecommendationResponse
+				if err := json.Unmarshal(body, &resp); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if len(resp.Recommendations) == 0 {
+					t.Error("expected at least one recommendation for over-provisioned pods")
+				}
+				for _, rec := range resp.Recommendations {
+					if rec.Deployment == "" {
+						t.Error("Deployment should not be empty")
+					}
+					if rec.MonthlySavingsJPY <= 0 {
+						t.Errorf("MonthlySavingsJPY = %d, want > 0", rec.MonthlySavingsJPY)
+					}
+					if rec.Message == "" {
+						t.Error("Message should not be empty")
+					}
+				}
+			},
+		},
+		{
+			name:       "well-provisioned pods return no recommendations",
+			lister:     &fakePodLister{pods: wellProvisionedPods()},
+			wantStatus: http.StatusOK,
+			check: func(t *testing.T, body []byte) {
+				t.Helper()
+				var resp api.RecommendationResponse
+				if err := json.Unmarshal(body, &resp); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if len(resp.Recommendations) != 0 {
+					t.Errorf("got %d recommendations, want 0 for well-provisioned pods", len(resp.Recommendations))
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			srv := integrationServer(tt.lister)
+			defer srv.Close()
+
+			result := doGet(t, srv.URL+"/api/v1/recommendations")
+
+			if result.StatusCode != tt.wantStatus {
+				t.Errorf("status = %d, want %d", result.StatusCode, tt.wantStatus)
+			}
+
+			if result.ContentType != "application/json" {
+				t.Errorf("Content-Type = %q, want %q", result.ContentType, "application/json")
+			}
+
+			if tt.check != nil {
+				tt.check(t, result.Body)
+			}
+		})
+	}
+}
+
+func TestIntegration_Schedules(t *testing.T) {
+	t.Parallel()
+
+	srv := integrationServer(&fakePodLister{pods: overProvisionedPods()})
+	defer srv.Close()
+
+	result := doGet(t, srv.URL+"/api/v1/schedules")
+
+	if result.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want %d", result.StatusCode, http.StatusOK)
+	}
+
+	if result.ContentType != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", result.ContentType, "application/json")
+	}
+
+	var schedResp api.ScheduleResponse
+	if err := json.Unmarshal(result.Body, &schedResp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(schedResp.Schedules) == 0 {
+		t.Error("expected at least one schedule for pods with data")
+	}
+}
+
+func TestIntegration_CronHPA(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		lister     *fakePodLister
+		path       string
+		wantStatus int
+		check      func(t *testing.T, body []byte)
+	}{
+		{
+			name:       "generates YAML for deployment",
+			lister:     &fakePodLister{pods: overProvisionedPods()},
+			path:       "/api/v1/cronhpa/web?namespace=default",
+			wantStatus: http.StatusOK,
+			check: func(t *testing.T, body []byte) {
+				t.Helper()
+				var resp api.CronHPAResponse
+				if err := json.Unmarshal(body, &resp); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if resp.YAML == "" {
+					t.Error("expected non-empty YAML")
+				}
+				if resp.Config.Namespace != "default" {
+					t.Errorf("Config.Namespace = %q, want %q", resp.Config.Namespace, "default")
+				}
+				if resp.Config.Deployment != "web" {
+					t.Errorf("Config.Deployment = %q, want %q", resp.Config.Deployment, "web")
+				}
+			},
+		},
+		{
+			name:       "missing namespace returns 400",
+			lister:     &fakePodLister{pods: []k8s.PodResource{}},
+			path:       "/api/v1/cronhpa/my-app",
+			wantStatus: http.StatusBadRequest,
+			check: func(t *testing.T, body []byte) {
+				t.Helper()
+				var resp api.ErrorResponse
+				if err := json.Unmarshal(body, &resp); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if resp.Code != "MISSING_NAMESPACE" {
+					t.Errorf("code = %q, want %q", resp.Code, "MISSING_NAMESPACE")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			srv := integrationServer(tt.lister)
+			defer srv.Close()
+
+			result := doGet(t, srv.URL+tt.path)
+
+			if result.StatusCode != tt.wantStatus {
+				t.Errorf("status = %d, want %d", result.StatusCode, tt.wantStatus)
+			}
+
+			if result.ContentType != "application/json" {
+				t.Errorf("Content-Type = %q, want %q", result.ContentType, "application/json")
+			}
+
+			if tt.check != nil {
+				tt.check(t, result.Body)
+			}
+		})
+	}
+}
+
+func TestIntegration_UnknownPath(t *testing.T) {
+	t.Parallel()
+
+	srv := integrationServer(&fakePodLister{pods: []k8s.PodResource{}})
+	defer srv.Close()
+
+	result := doGet(t, srv.URL+"/api/v1/unknown")
+
+	// chi returns 405 Method Not Allowed for known route prefixes and 404 for
+	// completely unknown paths. Either indicates the path is not served.
+	if result.StatusCode != http.StatusNotFound && result.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 404 or 405", result.StatusCode)
+	}
+}
+
+func TestIntegration_JSONContentType(t *testing.T) {
+	t.Parallel()
+
+	srv := integrationServer(&fakePodLister{pods: overProvisionedPods()})
+	defer srv.Close()
+
+	endpoints := []string{
+		"/api/v1/health",
+		"/api/v1/resources",
+		"/api/v1/recommendations",
+		"/api/v1/schedules",
+		"/api/v1/cronhpa/web?namespace=default",
+	}
+
+	for _, ep := range endpoints {
+		result := doGet(t, srv.URL+ep)
+
+		if result.ContentType != "application/json" {
+			t.Errorf("Content-Type for %s = %q, want %q", ep, result.ContentType, "application/json")
+		}
+	}
+}

--- a/frontend/src/app/schedules/page.test.tsx
+++ b/frontend/src/app/schedules/page.test.tsx
@@ -1,0 +1,156 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SchedulesResponse } from "@/types/api";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/schedules",
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("next/font/google", () => ({
+  Geist: () => ({ variable: "mock-geist-sans" }),
+  Geist_Mono: () => ({ variable: "mock-geist-mono" }),
+}));
+
+const mockSchedulesResponse: SchedulesResponse = {
+  schedules: [
+    {
+      namespace: "default",
+      deployment: "web",
+      hourly_loads: Array.from({ length: 24 }, (_, i) => ({
+        hour: i,
+        avg_cpu_usage: i >= 9 && i <= 18 ? 70 : 10,
+        avg_memory_usage: i >= 9 && i <= 18 ? 60 : 15,
+        sample_count: 10,
+      })),
+      low_load_hours: [0, 1, 2, 3, 4, 5, 22, 23],
+      is_weekend_low_load: true,
+    },
+    {
+      namespace: "production",
+      deployment: "api-server",
+      hourly_loads: Array.from({ length: 24 }, (_, i) => ({
+        hour: i,
+        avg_cpu_usage: 50,
+        avg_memory_usage: 40,
+        sample_count: 5,
+      })),
+      low_load_hours: [],
+      is_weekend_low_load: false,
+    },
+  ],
+};
+
+describe("SchedulesPage", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockSchedulesResponse),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders the page title", async () => {
+    const { default: SchedulesPage } = await import("./page");
+    render(<SchedulesPage />);
+    expect(screen.getByText("Schedule Analysis")).toBeInTheDocument();
+  });
+
+  it("renders schedule cards after loading", async () => {
+    const { default: SchedulesPage } = await import("./page");
+    render(<SchedulesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("web")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("api-server")).toBeInTheDocument();
+  });
+
+  it("displays namespace labels", async () => {
+    const { default: SchedulesPage } = await import("./page");
+    render(<SchedulesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("default")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("production")).toBeInTheDocument();
+  });
+
+  it("shows weekend low-load badge when detected", async () => {
+    const { default: SchedulesPage } = await import("./page");
+    render(<SchedulesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Weekend low-load detected")).toBeInTheDocument();
+    });
+  });
+
+  it("displays loading state initially", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise(() => {})));
+    const { default: SchedulesPage } = await import("./page");
+    render(<SchedulesPage />);
+
+    expect(screen.getByText("Loading schedules...")).toBeInTheDocument();
+  });
+
+  it("displays error on fetch failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () =>
+          Promise.resolve({
+            error: "Internal server error",
+            code: "INTERNAL_ERROR",
+          }),
+      }),
+    );
+    const { default: SchedulesPage } = await import("./page");
+    render(<SchedulesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Internal server error")).toBeInTheDocument();
+    });
+  });
+
+  it("shows no data message for empty schedules", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ schedules: [] }),
+      }),
+    );
+    const { default: SchedulesPage } = await import("./page");
+    render(<SchedulesPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("No schedule data available"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders CronHPA template buttons", async () => {
+    const { default: SchedulesPage } = await import("./page");
+    render(<SchedulesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("web")).toBeInTheDocument();
+    });
+
+    const buttons = screen.getAllByText("CronHPA Template");
+    expect(buttons).toHaveLength(2);
+  });
+});

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,0 +1,282 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ApiClientError,
+  fetchCronHPA,
+  fetchRecommendations,
+  fetchResources,
+  fetchSchedules,
+} from "./api";
+
+describe("API Client", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ pods: [], deployments: [] }),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("fetchResources", () => {
+    it("calls the resources endpoint", async () => {
+      await fetchResources();
+
+      expect(fetch).toHaveBeenCalledWith(
+        "http://localhost:8080/api/v1/resources",
+      );
+    });
+
+    it("passes namespace and deployment as query params", async () => {
+      await fetchResources({ namespace: "prod", deployment: "api" });
+
+      expect(fetch).toHaveBeenCalledWith(
+        "http://localhost:8080/api/v1/resources?namespace=prod&deployment=api",
+      );
+    });
+
+    it("returns parsed JSON response", async () => {
+      const mockData = {
+        pods: [{ pod_name: "test-pod" }],
+        deployments: [],
+      };
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve(mockData),
+        }),
+      );
+
+      const result = await fetchResources();
+      expect(result).toEqual(mockData);
+    });
+  });
+
+  describe("fetchRecommendations", () => {
+    it("calls the recommendations endpoint", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ recommendations: [] }),
+        }),
+      );
+
+      await fetchRecommendations();
+
+      expect(fetch).toHaveBeenCalledWith(
+        "http://localhost:8080/api/v1/recommendations",
+      );
+    });
+
+    it("passes filter params", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ recommendations: [] }),
+        }),
+      );
+
+      await fetchRecommendations({ namespace: "staging" });
+
+      expect(fetch).toHaveBeenCalledWith(
+        "http://localhost:8080/api/v1/recommendations?namespace=staging",
+      );
+    });
+  });
+
+  describe("fetchSchedules", () => {
+    it("calls the schedules endpoint", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ schedules: [] }),
+        }),
+      );
+
+      await fetchSchedules();
+
+      expect(fetch).toHaveBeenCalledWith(
+        "http://localhost:8080/api/v1/schedules",
+      );
+    });
+  });
+
+  describe("fetchCronHPA", () => {
+    it("calls the cronhpa endpoint with deployment and namespace", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ yaml: "", config: {} }),
+        }),
+      );
+
+      await fetchCronHPA("my-app", "default");
+
+      expect(fetch).toHaveBeenCalledWith(
+        "http://localhost:8080/api/v1/cronhpa/my-app?namespace=default",
+      );
+    });
+
+    it("encodes deployment name in URL", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ yaml: "", config: {} }),
+        }),
+      );
+
+      await fetchCronHPA("my app", "default");
+
+      expect(fetch).toHaveBeenCalledWith(
+        "http://localhost:8080/api/v1/cronhpa/my%20app?namespace=default",
+      );
+    });
+
+    it("works without namespace", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ yaml: "", config: {} }),
+        }),
+      );
+
+      await fetchCronHPA("my-app");
+
+      expect(fetch).toHaveBeenCalledWith(
+        "http://localhost:8080/api/v1/cronhpa/my-app",
+      );
+    });
+  });
+
+  describe("error handling", () => {
+    it("throws ApiClientError on non-ok response with JSON body", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 500,
+          json: () =>
+            Promise.resolve({
+              error: "Internal server error",
+              code: "INTERNAL_ERROR",
+            }),
+        }),
+      );
+
+      try {
+        await fetchResources();
+        expect.fail("should have thrown");
+      } catch (err: unknown) {
+        expect(err).toBeInstanceOf(ApiClientError);
+        if (err instanceof ApiClientError) {
+          expect(err.message).toBe("Internal server error");
+          expect(err.status).toBe(500);
+          expect(err.code).toBe("INTERNAL_ERROR");
+        }
+      }
+    });
+
+    it("throws ApiClientError with default message for non-JSON error body", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 502,
+          json: () => Promise.reject(new Error("not json")),
+        }),
+      );
+
+      try {
+        await fetchResources();
+        expect.fail("should have thrown");
+      } catch (err: unknown) {
+        expect(err).toBeInstanceOf(ApiClientError);
+        if (err instanceof ApiClientError) {
+          expect(err.status).toBe(502);
+          expect(err.code).toBe("UNKNOWN_ERROR");
+          expect(err.message).toContain("502");
+        }
+      }
+    });
+
+    it("throws ApiClientError for 400 Bad Request", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 400,
+          json: () =>
+            Promise.resolve({
+              error: "namespace is required",
+              code: "MISSING_NAMESPACE",
+            }),
+        }),
+      );
+
+      try {
+        await fetchCronHPA("my-app");
+        expect.fail("should have thrown");
+      } catch (err: unknown) {
+        expect(err).toBeInstanceOf(ApiClientError);
+        if (err instanceof ApiClientError) {
+          expect(err.status).toBe(400);
+          expect(err.code).toBe("MISSING_NAMESPACE");
+        }
+      }
+    });
+
+    it("propagates network errors from fetch", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockRejectedValue(new TypeError("Failed to fetch")),
+      );
+
+      try {
+        await fetchResources();
+        expect.fail("should have thrown");
+      } catch (err: unknown) {
+        expect(err).toBeInstanceOf(TypeError);
+        if (err instanceof TypeError) {
+          expect(err.message).toBe("Failed to fetch");
+        }
+      }
+    });
+  });
+
+  describe("buildQueryString edge cases", () => {
+    it("omits empty namespace from query string", async () => {
+      await fetchResources({ namespace: "" });
+
+      expect(fetch).toHaveBeenCalledWith(
+        "http://localhost:8080/api/v1/resources",
+      );
+    });
+
+    it("omits undefined deployment from query string", async () => {
+      await fetchResources({ namespace: "prod" });
+
+      expect(fetch).toHaveBeenCalledWith(
+        "http://localhost:8080/api/v1/resources?namespace=prod",
+      );
+    });
+
+    it("omits both when empty", async () => {
+      await fetchResources({});
+
+      expect(fetch).toHaveBeenCalledWith(
+        "http://localhost:8080/api/v1/resources",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- バックエンドAPI統合テスト (`integration_test.go`) を追加。全エンドポイント (health, resources, recommendations, schedules, cronhpa) を `httptest.Server` 経由で統合的に検証
- フロントエンドにスケジュールページテスト (`page.test.tsx`) と APIクライアントユニットテスト (`api.test.ts`) を追加。エラーハンドリング、クエリパラメータ構築、ネットワークエラー伝播を網羅
- CI設定を `golangci-lint-action@v7` 公式アクションに移行し、lint結果のキャッシュ効率を改善

## Test plan
- [x] `go test -v -race ./...` 全5パッケージ全パス
- [x] `golangci-lint run ./...` 0 issues
- [x] `npx vitest run` 5ファイル41テスト全パス
- [x] `npm run build` 正常完了
- [x] `make check` 全パス
- [x] `actionlint` CI YAML検証パス

Closes #11