### PR TITLE
fix(security): add JWT auth, fix K8s router injection, env-based CORS

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -3,24 +3,80 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"os"
 
+	"github.com/akaitigo/infra-miru/backend/internal/analyzer"
 	"github.com/akaitigo/infra-miru/backend/internal/api"
 	"github.com/akaitigo/infra-miru/backend/internal/config"
+	"github.com/akaitigo/infra-miru/backend/internal/cost"
+	"github.com/akaitigo/infra-miru/backend/internal/db"
+	"github.com/akaitigo/infra-miru/backend/internal/k8s"
 )
 
 func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "fatal: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
 	cfg, err := config.Load()
 	if err != nil {
-		log.Fatalf("failed to load config: %v", err)
+		return fmt.Errorf("load config: %w", err)
 	}
 
-	router := api.NewRouter(nil)
+	// Database connection and migration.
+	dbURL := cfg.DatabaseURL()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pool, err := db.Connect(ctx, dbURL)
+	if err != nil {
+		return fmt.Errorf("connect to database: %w", err)
+	}
+	defer pool.Close()
+
+	log.Println("database connected")
+
+	err = db.RunMigrations(dbURL)
+	if err != nil {
+		return fmt.Errorf("run migrations: %w", err)
+	}
+
+	log.Println("database migrations applied")
+
+	// Kubernetes client initialization.
+	k8sClient, err := k8s.Connect(cfg.KubeConfig)
+	if err != nil {
+		return fmt.Errorf("connect to kubernetes: %w", err)
+	}
+
+	log.Println("kubernetes client connected")
+
+	// Build dependencies for the router.
+	deps := &api.RouterDeps{
+		PodLister:  k8sClient,
+		Analyzer:   analyzer.NewAnalyzer(),
+		Calculator: cost.NewCalculator(),
+	}
+
+	routerCfg := &api.RouterConfig{
+		CORSOrigins: cfg.CORSOrigins,
+		JWTSecret:   cfg.JWTSecret,
+	}
+
+	router := api.NewRouter(deps, routerCfg)
 	srv := api.NewServer(cfg.Port, router)
 
 	log.Printf("infra-miru server starting on port %s", cfg.Port)
 
-	if err := srv.Run(context.Background()); err != nil {
-		log.Fatalf("server error: %v", err)
+	if err := srv.Run(ctx); err != nil {
+		return fmt.Errorf("server: %w", err)
 	}
+
+	return nil
 }

--- a/backend/internal/api/auth.go
+++ b/backend/internal/api/auth.go
@@ -1,0 +1,123 @@
+package api
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// jwtHeader represents the header portion of a JWT.
+type jwtHeader struct {
+	Alg string `json:"alg"`
+	Typ string `json:"typ"`
+}
+
+// jwtClaims represents the payload portion of a JWT with standard claims.
+type jwtClaims struct {
+	Sub string `json:"sub"`
+	Exp int64  `json:"exp"`
+	Iat int64  `json:"iat"`
+}
+
+// JWTAuth returns middleware that validates Bearer JWT tokens using HMAC-SHA256.
+// Requests without a valid token receive a 401 Unauthorized response.
+func JWTAuth(secret string) func(http.Handler) http.Handler {
+	secretBytes := []byte(secret)
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			token, ok := extractBearerToken(r)
+			if !ok {
+				JSONError(w, http.StatusUnauthorized, "missing or malformed Authorization header", "AUTH_MISSING")
+				return
+			}
+
+			if err := validateJWT(token, secretBytes); err != nil {
+				JSONError(w, http.StatusUnauthorized, fmt.Sprintf("invalid token: %v", err), "AUTH_INVALID")
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// extractBearerToken extracts the token from an "Authorization: Bearer <token>" header.
+func extractBearerToken(r *http.Request) (string, bool) {
+	auth := r.Header.Get("Authorization")
+	if auth == "" {
+		return "", false
+	}
+
+	const prefix = "Bearer "
+	if !strings.HasPrefix(auth, prefix) {
+		return "", false
+	}
+
+	token := strings.TrimSpace(auth[len(prefix):])
+	if token == "" {
+		return "", false
+	}
+
+	return token, true
+}
+
+// validateJWT verifies the JWT signature and expiration using HMAC-SHA256.
+func validateJWT(token string, secret []byte) error {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return fmt.Errorf("token must have 3 parts, got %d", len(parts))
+	}
+
+	// Decode and validate header.
+	headerBytes, decErr := base64.RawURLEncoding.DecodeString(parts[0])
+	if decErr != nil {
+		return fmt.Errorf("decode header: %w", decErr)
+	}
+
+	var header jwtHeader
+	if unmarshalErr := json.Unmarshal(headerBytes, &header); unmarshalErr != nil {
+		return fmt.Errorf("parse header: %w", unmarshalErr)
+	}
+
+	if header.Alg != "HS256" {
+		return fmt.Errorf("unsupported algorithm: %s", header.Alg)
+	}
+
+	// Verify HMAC-SHA256 signature.
+	signingInput := parts[0] + "." + parts[1]
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(signingInput))
+	expectedSig := mac.Sum(nil)
+
+	actualSig, sigErr := base64.RawURLEncoding.DecodeString(parts[2])
+	if sigErr != nil {
+		return fmt.Errorf("decode signature: %w", sigErr)
+	}
+
+	if !hmac.Equal(expectedSig, actualSig) {
+		return fmt.Errorf("signature verification failed")
+	}
+
+	// Decode and validate claims.
+	claimsBytes, claimsErr := base64.RawURLEncoding.DecodeString(parts[1])
+	if claimsErr != nil {
+		return fmt.Errorf("decode claims: %w", claimsErr)
+	}
+
+	var claims jwtClaims
+	if parseErr := json.Unmarshal(claimsBytes, &claims); parseErr != nil {
+		return fmt.Errorf("parse claims: %w", parseErr)
+	}
+
+	if claims.Exp > 0 && time.Now().Unix() > claims.Exp {
+		return fmt.Errorf("token expired")
+	}
+
+	return nil
+}

--- a/backend/internal/api/auth_test.go
+++ b/backend/internal/api/auth_test.go
@@ -1,0 +1,134 @@
+package api_test
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/akaitigo/infra-miru/backend/internal/api"
+)
+
+const testJWTSecret = "test-secret-key-for-unit-tests"
+
+// buildJWT constructs a minimal HS256 JWT for testing.
+func buildJWT(t *testing.T, secret string, exp int64) string {
+	t.Helper()
+
+	header, err := json.Marshal(map[string]string{"alg": "HS256", "typ": "JWT"})
+	if err != nil {
+		t.Fatalf("marshal header: %v", err)
+	}
+
+	claims, err := json.Marshal(map[string]any{
+		"sub": "test-user",
+		"iat": time.Now().Unix(),
+		"exp": exp,
+	})
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+
+	headerB64 := base64.RawURLEncoding.EncodeToString(header)
+	claimsB64 := base64.RawURLEncoding.EncodeToString(claims)
+
+	signingInput := headerB64 + "." + claimsB64
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(signingInput))
+	sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+
+	return headerB64 + "." + claimsB64 + "." + sig
+}
+
+func TestJWTAuth(t *testing.T) {
+	t.Parallel()
+
+	okHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+
+	tests := []struct {
+		name       string
+		authHeader string
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "valid token passes",
+			authHeader: "Bearer " + buildJWT(t, testJWTSecret, time.Now().Add(time.Hour).Unix()),
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "missing Authorization header",
+			authHeader: "",
+			wantStatus: http.StatusUnauthorized,
+			wantCode:   "AUTH_MISSING",
+		},
+		{
+			name:       "malformed header without Bearer prefix",
+			authHeader: "Token abc",
+			wantStatus: http.StatusUnauthorized,
+			wantCode:   "AUTH_MISSING",
+		},
+		{
+			name:       "empty Bearer token",
+			authHeader: "Bearer ",
+			wantStatus: http.StatusUnauthorized,
+			wantCode:   "AUTH_MISSING",
+		},
+		{
+			name:       "expired token",
+			authHeader: "Bearer " + buildJWT(t, testJWTSecret, time.Now().Add(-time.Hour).Unix()),
+			wantStatus: http.StatusUnauthorized,
+			wantCode:   "AUTH_INVALID",
+		},
+		{
+			name:       "wrong secret",
+			authHeader: "Bearer " + buildJWT(t, "wrong-secret", time.Now().Add(time.Hour).Unix()),
+			wantStatus: http.StatusUnauthorized,
+			wantCode:   "AUTH_INVALID",
+		},
+		{
+			name:       "garbage token",
+			authHeader: "Bearer not.a.valid.jwt",
+			wantStatus: http.StatusUnauthorized,
+			wantCode:   "AUTH_INVALID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			middleware := api.JWTAuth(testJWTSecret)
+			handler := middleware(okHandler)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/resources", nil)
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
+			}
+
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+
+			if tt.wantCode != "" {
+				var errResp api.ErrorResponse
+				if err := json.NewDecoder(rec.Body).Decode(&errResp); err != nil {
+					t.Fatalf("failed to decode error response: %v", err)
+				}
+				if errResp.Code != tt.wantCode {
+					t.Errorf("error code = %q, want %q", errResp.Code, tt.wantCode)
+				}
+			}
+		})
+	}
+}

--- a/backend/internal/api/health_test.go
+++ b/backend/internal/api/health_test.go
@@ -60,7 +60,7 @@ func TestHealthHandler(t *testing.T) {
 func TestHealthHandlerViaRouter(t *testing.T) {
 	t.Parallel()
 
-	router := api.NewRouter(nil)
+	router := api.NewRouter(nil, nil)
 	srv := httptest.NewServer(router)
 	defer srv.Close()
 

--- a/backend/internal/api/integration_test.go
+++ b/backend/internal/api/integration_test.go
@@ -31,7 +31,7 @@ func integrationServer(lister *fakePodLister) *httptest.Server {
 		PodLister:  lister,
 		Analyzer:   analyzer.NewAnalyzer(),
 		Calculator: cost.NewCalculator(),
-	})
+	}, nil)
 	return httptest.NewServer(router)
 }
 

--- a/backend/internal/api/recommendation_handler_test.go
+++ b/backend/internal/api/recommendation_handler_test.go
@@ -188,7 +188,7 @@ func TestRecommendationHandlerViaRouter(t *testing.T) {
 		PodLister:  lister,
 		Analyzer:   analyzer.NewAnalyzer(),
 		Calculator: cost.NewCalculator(),
-	})
+	}, nil)
 
 	srv := httptest.NewServer(router)
 	defer srv.Close()

--- a/backend/internal/api/resource_handler_test.go
+++ b/backend/internal/api/resource_handler_test.go
@@ -172,7 +172,7 @@ func TestResourceHandlerViaRouter(t *testing.T) {
 		PodLister:  lister,
 		Analyzer:   analyzer.NewAnalyzer(),
 		Calculator: nil, // not needed for resource endpoint
-	})
+	}, nil)
 
 	srv := httptest.NewServer(router)
 	defer srv.Close()

--- a/backend/internal/api/response.go
+++ b/backend/internal/api/response.go
@@ -12,7 +12,7 @@ type ErrorResponse struct {
 }
 
 // JSON writes data as a JSON response with the given status code.
-func JSON(w http.ResponseWriter, status int, data interface{}) {
+func JSON(w http.ResponseWriter, status int, data any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -21,10 +21,22 @@ type RouterDeps struct {
 	Calculator *cost.Calculator
 }
 
+// RouterConfig holds configuration for the router middleware.
+type RouterConfig struct {
+	JWTSecret   string
+	CORSOrigins []string
+}
+
 // NewRouter creates and configures a chi router with middleware and routes.
 // Pass nil for deps to register only the health endpoint (useful for tests).
-func NewRouter(deps *RouterDeps) *chi.Mux {
+// Pass nil for cfg to use development defaults (no auth, localhost CORS).
+func NewRouter(deps *RouterDeps, cfg *RouterConfig) *chi.Mux {
 	r := chi.NewRouter()
+
+	corsOrigins := []string{"http://localhost:3000", "http://localhost:8080"}
+	if cfg != nil && len(cfg.CORSOrigins) > 0 {
+		corsOrigins = cfg.CORSOrigins
+	}
 
 	// Middleware stack
 	r.Use(middleware.RequestID)
@@ -34,7 +46,7 @@ func NewRouter(deps *RouterDeps) *chi.Mux {
 	r.Use(middleware.CleanPath)
 	r.Use(middleware.Timeout(requestTimeout))
 	r.Use(cors.Handler(cors.Options{
-		AllowedOrigins:   []string{"http://localhost:3000", "http://localhost:8080"},
+		AllowedOrigins:   corsOrigins,
 		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token"},
 		ExposedHeaders:   []string{"Link"},
@@ -44,14 +56,22 @@ func NewRouter(deps *RouterDeps) *chi.Mux {
 
 	// Routes
 	r.Route("/api/v1", func(r chi.Router) {
+		// Health endpoint is public (no auth required).
 		r.Get("/health", HealthHandler())
 
-		if deps != nil {
-			r.Get("/resources", ResourceHandler(deps.PodLister, deps.Analyzer))
-			r.Get("/recommendations", RecommendationHandler(deps.PodLister, deps.Analyzer, deps.Calculator))
-			r.Get("/schedules", ScheduleHandler(deps.PodLister, deps.Analyzer))
-			r.Get("/cronhpa/{deployment}", CronHPAHandler(deps.PodLister, deps.Analyzer))
-		}
+		// Protected routes require JWT authentication.
+		r.Group(func(r chi.Router) {
+			if cfg != nil && cfg.JWTSecret != "" {
+				r.Use(JWTAuth(cfg.JWTSecret))
+			}
+
+			if deps != nil {
+				r.Get("/resources", ResourceHandler(deps.PodLister, deps.Analyzer))
+				r.Get("/recommendations", RecommendationHandler(deps.PodLister, deps.Analyzer, deps.Calculator))
+				r.Get("/schedules", ScheduleHandler(deps.PodLister, deps.Analyzer))
+				r.Get("/cronhpa/{deployment}", CronHPAHandler(deps.PodLister, deps.Analyzer))
+			}
+		})
 	})
 
 	return r

--- a/backend/internal/api/schedule_handler_test.go
+++ b/backend/internal/api/schedule_handler_test.go
@@ -245,7 +245,7 @@ func TestCronHPAHandler(t *testing.T) {
 				PodLister:  tt.lister,
 				Analyzer:   analyzer.NewAnalyzer(),
 				Calculator: cost.NewCalculator(),
-			})
+			}, nil)
 
 			srv := httptest.NewServer(router)
 			defer srv.Close()
@@ -302,7 +302,7 @@ func TestScheduleHandlerViaRouter(t *testing.T) {
 		PodLister:  lister,
 		Analyzer:   analyzer.NewAnalyzer(),
 		Calculator: cost.NewCalculator(),
-	})
+	}, nil)
 
 	srv := httptest.NewServer(router)
 	defer srv.Close()

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -19,6 +19,8 @@ type Config struct {
 	DBName        string
 	KubeConfig    string
 	PrometheusURL string
+	JWTSecret     string
+	CORSOrigins   []string
 }
 
 // DatabaseURL returns a PostgreSQL connection string built from the config fields.
@@ -41,6 +43,8 @@ func Load() (*Config, error) {
 		DBName:        os.Getenv("DB_NAME"),
 		KubeConfig:    os.Getenv("KUBECONFIG"),
 		PrometheusURL: os.Getenv("PROMETHEUS_URL"),
+		CORSOrigins:   parseCORSOrigins(os.Getenv("CORS_ORIGINS")),
+		JWTSecret:     os.Getenv("JWT_SECRET"),
 	}
 
 	if err := cfg.validate(); err != nil {
@@ -62,6 +66,7 @@ func (c *Config) validate() error {
 		{name: "DB_PASSWORD", value: c.DBPassword},
 		{name: "DB_NAME", value: c.DBName},
 		{name: "KUBECONFIG", value: c.KubeConfig},
+		{name: "JWT_SECRET", value: c.JWTSecret},
 	}
 
 	var missing []string
@@ -86,4 +91,20 @@ func getEnvOrDefault(key, defaultValue string) string {
 		return v
 	}
 	return defaultValue
+}
+
+// parseCORSOrigins splits a comma-separated CORS_ORIGINS value into a slice.
+// Returns sensible development defaults when the input is empty.
+func parseCORSOrigins(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return []string{"http://localhost:3000", "http://localhost:8080"}
+	}
+	parts := strings.Split(raw, ",")
+	origins := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			origins = append(origins, trimmed)
+		}
+	}
+	return origins
 }

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -16,6 +16,8 @@ func setAllEnvVars(t *testing.T) {
 	t.Setenv("DB_NAME", "testdb")
 	t.Setenv("KUBECONFIG", "/home/test/.kube/config")
 	t.Setenv("PROMETHEUS_URL", "http://prometheus:9090")
+	t.Setenv("JWT_SECRET", "test-jwt-secret")
+	t.Setenv("CORS_ORIGINS", "http://localhost:3000,http://localhost:8080")
 }
 
 func clearAllEnvVars(t *testing.T) {
@@ -23,6 +25,7 @@ func clearAllEnvVars(t *testing.T) {
 	for _, key := range []string{
 		"PORT", "DB_HOST", "DB_PORT", "DB_USER",
 		"DB_PASSWORD", "DB_NAME", "KUBECONFIG", "PROMETHEUS_URL",
+		"JWT_SECRET", "CORS_ORIGINS",
 	} {
 		t.Setenv(key, "")
 	}
@@ -57,6 +60,12 @@ func TestLoad_AllRequiredVarsSet(t *testing.T) {
 	if cfg.PrometheusURL != "http://prometheus:9090" {
 		t.Errorf("PrometheusURL = %q, want %q", cfg.PrometheusURL, "http://prometheus:9090")
 	}
+	if cfg.JWTSecret != "test-jwt-secret" {
+		t.Errorf("JWTSecret = %q, want %q", cfg.JWTSecret, "test-jwt-secret")
+	}
+	if len(cfg.CORSOrigins) != 2 {
+		t.Errorf("CORSOrigins length = %d, want 2", len(cfg.CORSOrigins))
+	}
 }
 
 func TestLoad_DefaultPort(t *testing.T) {
@@ -66,6 +75,7 @@ func TestLoad_DefaultPort(t *testing.T) {
 	t.Setenv("DB_PASSWORD", "testpass")
 	t.Setenv("DB_NAME", "testdb")
 	t.Setenv("KUBECONFIG", "/home/test/.kube/config")
+	t.Setenv("JWT_SECRET", "test-jwt-secret")
 
 	cfg, err := config.Load()
 	if err != nil {
@@ -79,37 +89,43 @@ func TestLoad_DefaultPort(t *testing.T) {
 
 func TestLoad_MissingRequiredVars(t *testing.T) {
 	tests := []struct {
-		name    string
 		setVars map[string]string
+		name    string
 	}{
 		{
 			name: "missing DB_HOST",
 			setVars: map[string]string{
-				"DB_USER": "u", "DB_PASSWORD": "p", "DB_NAME": "d", "KUBECONFIG": "/k",
+				"DB_USER": "u", "DB_PASSWORD": "p", "DB_NAME": "d", "KUBECONFIG": "/k", "JWT_SECRET": "s",
 			},
 		},
 		{
 			name: "missing DB_USER",
 			setVars: map[string]string{
-				"DB_HOST": "h", "DB_PASSWORD": "p", "DB_NAME": "d", "KUBECONFIG": "/k",
+				"DB_HOST": "h", "DB_PASSWORD": "p", "DB_NAME": "d", "KUBECONFIG": "/k", "JWT_SECRET": "s",
 			},
 		},
 		{
 			name: "missing DB_PASSWORD",
 			setVars: map[string]string{
-				"DB_HOST": "h", "DB_USER": "u", "DB_NAME": "d", "KUBECONFIG": "/k",
+				"DB_HOST": "h", "DB_USER": "u", "DB_NAME": "d", "KUBECONFIG": "/k", "JWT_SECRET": "s",
 			},
 		},
 		{
 			name: "missing DB_NAME",
 			setVars: map[string]string{
-				"DB_HOST": "h", "DB_USER": "u", "DB_PASSWORD": "p", "KUBECONFIG": "/k",
+				"DB_HOST": "h", "DB_USER": "u", "DB_PASSWORD": "p", "KUBECONFIG": "/k", "JWT_SECRET": "s",
 			},
 		},
 		{
 			name: "missing KUBECONFIG",
 			setVars: map[string]string{
-				"DB_HOST": "h", "DB_USER": "u", "DB_PASSWORD": "p", "DB_NAME": "d",
+				"DB_HOST": "h", "DB_USER": "u", "DB_PASSWORD": "p", "DB_NAME": "d", "JWT_SECRET": "s",
+			},
+		},
+		{
+			name: "missing JWT_SECRET",
+			setVars: map[string]string{
+				"DB_HOST": "h", "DB_USER": "u", "DB_PASSWORD": "p", "DB_NAME": "d", "KUBECONFIG": "/k",
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- CRITICAL: Added JWT authentication middleware for all API endpoints (health excluded)
- HIGH: Fixed NewRouter(nil) → proper K8s client initialization and injection
- HIGH: CORS AllowedOrigins moved from hardcode to CORS_ORIGINS env var
- MEDIUM: Added DB migration call on startup

## Test plan
- [x] go build / go vet / go test -race all pass
- [x] golangci-lint 0 issues
- [x] 7 auth test cases (valid/expired/wrong-secret/missing-header etc.)