### PR TITLE
ci: update Node.js 20 to 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: frontend/package-lock.json
 


### PR DESCRIPTION
## 概要
CI の \`node-version: "20"\` を \`"22"\` に更新する。

## 背景
Node.js 20 は 2026-04 に EOL を迎え、deprecation 対応期限（2026年6月）を超過していた。org 内の他リポは Node 22 が標準。

## 変更内容
- \`.github/workflows/ci.yml\`: frontend ジョブの \`node-version\` を 20 → 22

## 検証
- actionlint パス