### PR TITLE
fix: require JWT exp claim and support in-cluster k8s config

### DIFF
--- a/backend/internal/api/auth.go
+++ b/backend/internal/api/auth.go
@@ -115,7 +115,13 @@ func validateJWT(token string, secret []byte) error {
 		return fmt.Errorf("parse claims: %w", parseErr)
 	}
 
-	if claims.Exp > 0 && time.Now().Unix() > claims.Exp {
+	// The exp claim is mandatory: a missing or non-positive value would
+	// otherwise yield a token that never expires.
+	if claims.Exp <= 0 {
+		return fmt.Errorf("token missing exp claim")
+	}
+
+	if time.Now().Unix() > claims.Exp {
 		return fmt.Errorf("token expired")
 	}
 

--- a/backend/internal/api/auth_test.go
+++ b/backend/internal/api/auth_test.go
@@ -15,8 +15,8 @@ import (
 
 const testJWTSecret = "test-secret-key-for-unit-tests"
 
-// buildJWT constructs a minimal HS256 JWT for testing.
-func buildJWT(t *testing.T, secret string, exp int64) string {
+// signJWT constructs and signs a minimal HS256 JWT from the given claims.
+func signJWT(t *testing.T, secret string, claims map[string]any) string {
 	t.Helper()
 
 	header, err := json.Marshal(map[string]string{"alg": "HS256", "typ": "JWT"})
@@ -24,17 +24,13 @@ func buildJWT(t *testing.T, secret string, exp int64) string {
 		t.Fatalf("marshal header: %v", err)
 	}
 
-	claims, err := json.Marshal(map[string]any{
-		"sub": "test-user",
-		"iat": time.Now().Unix(),
-		"exp": exp,
-	})
+	claimsJSON, err := json.Marshal(claims)
 	if err != nil {
 		t.Fatalf("marshal claims: %v", err)
 	}
 
 	headerB64 := base64.RawURLEncoding.EncodeToString(header)
-	claimsB64 := base64.RawURLEncoding.EncodeToString(claims)
+	claimsB64 := base64.RawURLEncoding.EncodeToString(claimsJSON)
 
 	signingInput := headerB64 + "." + claimsB64
 	mac := hmac.New(sha256.New, []byte(secret))
@@ -42,6 +38,27 @@ func buildJWT(t *testing.T, secret string, exp int64) string {
 	sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
 
 	return headerB64 + "." + claimsB64 + "." + sig
+}
+
+// buildJWT constructs a minimal HS256 JWT with sub, iat and exp claims.
+func buildJWT(t *testing.T, secret string, exp int64) string {
+	t.Helper()
+
+	return signJWT(t, secret, map[string]any{
+		"sub": "test-user",
+		"iat": time.Now().Unix(),
+		"exp": exp,
+	})
+}
+
+// buildJWTNoExp constructs an HS256 JWT that omits the exp claim entirely.
+func buildJWTNoExp(t *testing.T, secret string) string {
+	t.Helper()
+
+	return signJWT(t, secret, map[string]any{
+		"sub": "test-user",
+		"iat": time.Now().Unix(),
+	})
 }
 
 func TestJWTAuth(t *testing.T) {
@@ -84,6 +101,18 @@ func TestJWTAuth(t *testing.T) {
 		{
 			name:       "expired token",
 			authHeader: "Bearer " + buildJWT(t, testJWTSecret, time.Now().Add(-time.Hour).Unix()),
+			wantStatus: http.StatusUnauthorized,
+			wantCode:   "AUTH_INVALID",
+		},
+		{
+			name:       "missing exp claim is rejected",
+			authHeader: "Bearer " + buildJWTNoExp(t, testJWTSecret),
+			wantStatus: http.StatusUnauthorized,
+			wantCode:   "AUTH_INVALID",
+		},
+		{
+			name:       "zero exp claim is rejected",
+			authHeader: "Bearer " + buildJWT(t, testJWTSecret, 0),
 			wantStatus: http.StatusUnauthorized,
 			wantCode:   "AUTH_INVALID",
 		},

--- a/backend/internal/k8s/connector.go
+++ b/backend/internal/k8s/connector.go
@@ -1,18 +1,28 @@
 package k8s
 
 import (
+	"errors"
 	"fmt"
 
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	metricsv "k8s.io/metrics/pkg/client/clientset/versioned"
 )
 
-// Connect creates a Client from the kubeconfig file at the given path.
+// inClusterConfigFunc loads a REST config from the in-cluster environment.
+type inClusterConfigFunc func() (*rest.Config, error)
+
+// fromFlagsConfigFunc loads a REST config from a kubeconfig file.
+type fromFlagsConfigFunc func(masterURL, kubeconfigPath string) (*rest.Config, error)
+
+// Connect creates a Client, preferring the in-cluster configuration (available
+// when running inside a Kubernetes Pod) and falling back to the kubeconfig file
+// at the given path when the process is not running inside a cluster.
 func Connect(kubeconfigPath string) (*Client, error) {
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	config, err := resolveConfig(kubeconfigPath, rest.InClusterConfig, clientcmd.BuildConfigFromFlags)
 	if err != nil {
-		return nil, fmt.Errorf("build kubeconfig: %w", err)
+		return nil, err
 	}
 
 	clientset, err := kubernetes.NewForConfig(config)
@@ -26,4 +36,30 @@ func Connect(kubeconfigPath string) (*Client, error) {
 	}
 
 	return NewClient(clientset, metricsClient), nil
+}
+
+// resolveConfig resolves a Kubernetes REST config. It first attempts the
+// in-cluster configuration and falls back to the kubeconfig file when the
+// process is not running inside a cluster. When both sources fail the returned
+// error wraps both underlying failures.
+func resolveConfig(
+	kubeconfigPath string,
+	inCluster inClusterConfigFunc,
+	fromFlags fromFlagsConfigFunc,
+) (*rest.Config, error) {
+	config, inClusterErr := inCluster()
+	if inClusterErr == nil {
+		return config, nil
+	}
+
+	config, flagsErr := fromFlags("", kubeconfigPath)
+	if flagsErr != nil {
+		return nil, fmt.Errorf(
+			"resolve kubernetes config (kubeconfig %q): %w",
+			kubeconfigPath,
+			errors.Join(inClusterErr, flagsErr),
+		)
+	}
+
+	return config, nil
 }

--- a/backend/internal/k8s/connector_test.go
+++ b/backend/internal/k8s/connector_test.go
@@ -1,0 +1,90 @@
+package k8s
+
+import (
+	"errors"
+	"testing"
+
+	"k8s.io/client-go/rest"
+)
+
+func TestResolveConfig(t *testing.T) {
+	t.Parallel()
+
+	const (
+		inClusterHost  = "https://in-cluster.local:443"
+		kubeconfigHost = "https://kubeconfig.local:6443"
+	)
+
+	errKubeconfigMissing := errors.New("kubeconfig not found")
+
+	tests := []struct {
+		name      string
+		inCluster inClusterConfigFunc
+		fromFlags fromFlagsConfigFunc
+		wantHost  string
+		wantErr   bool
+		wantErrIs []error
+	}{
+		{
+			name: "prefers in-cluster config when running inside a cluster",
+			inCluster: func() (*rest.Config, error) {
+				return &rest.Config{Host: inClusterHost}, nil
+			},
+			fromFlags: func(_, _ string) (*rest.Config, error) {
+				return &rest.Config{Host: kubeconfigHost}, nil
+			},
+			wantHost: inClusterHost,
+		},
+		{
+			name: "falls back to kubeconfig when not running in a cluster",
+			inCluster: func() (*rest.Config, error) {
+				return nil, rest.ErrNotInCluster
+			},
+			fromFlags: func(_, _ string) (*rest.Config, error) {
+				return &rest.Config{Host: kubeconfigHost}, nil
+			},
+			wantHost: kubeconfigHost,
+		},
+		{
+			name: "returns error wrapping both failures when in-cluster and kubeconfig fail",
+			inCluster: func() (*rest.Config, error) {
+				return nil, rest.ErrNotInCluster
+			},
+			fromFlags: func(_, _ string) (*rest.Config, error) {
+				return nil, errKubeconfigMissing
+			},
+			wantErr:   true,
+			wantErrIs: []error{rest.ErrNotInCluster, errKubeconfigMissing},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			config, err := resolveConfig("/fake/kubeconfig", tt.inCluster, tt.fromFlags)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				for _, target := range tt.wantErrIs {
+					if !errors.Is(err, target) {
+						t.Errorf("error %q does not wrap %q", err, target)
+					}
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if config == nil {
+				t.Fatal("expected config, got nil")
+			}
+			if config.Host != tt.wantHost {
+				t.Errorf("Host = %q, want %q", config.Host, tt.wantHost)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要

2件のバックエンド Issue を1本のPRで修正する。

## #19 (security) JWT exp=0 で永続有効トークン許容
`validateJWT` の条件 `if claims.Exp > 0 && ...` により、`exp` が未設定（0）のトークンが有効期限チェックをスキップし永続有効になっていた。

- `exp` を必須化: `claims.Exp <= 0`（欠落・ゼロ値・負値）は `AUTH_INVALID` で拒否
- 有効期限判定を2段階に分離（正の `exp` 必須 → 未来時刻の比較）
- 境界テスト追加: `exp` なし / `exp=0` / 期限切れ / 有効

## #20 K8s in-cluster config 未対応
`Connect` が `clientcmd.BuildConfigFromFlags` のみを使用し、Pod 内実行時に kubeconfig が無く起動失敗していた。

- `rest.InClusterConfig()` を優先し、失敗時に kubeconfig へフォールバック
- 検出/フォールバックのロジックをテスト可能な `resolveConfig` に抽出（ローダーを注入）
- 両方失敗時は `errors.Join` で両エラーをラップ
- 単体テスト追加: in-cluster 優先 / kubeconfig フォールバック / 両失敗時のエラーラップ（`errors.Is` 検証）

## 検証
- `go build ./...` OK
- `go test -race -count=1 ./...` 全パッケージ pass
- `golangci-lint run ./...` 0 issues

Fixes #19, Fixes #20