### PR TITLE
ci: dependabot auto-merge workflow を追加

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,21 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dependabot/fetch-metadata@v3
+        id: meta
+      - name: Auto-merge patch and minor updates
+        if: steps.meta.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要
org 標準の dependabot auto-merge ワークフローを追加する（12リポ中、本リポのみ未設置だった）。

## 背景
2026-07-07 のバックログ一斉処理で、dependabot PR 滞留の根本原因が「workflow はあるが allow_auto_merge=false」だったことが判明。恒久対応として全リポを open-pos 方式（allow_auto_merge=true + required status checks + 本 workflow）に統一する。本リポは設定側の有効化は完了済みで、workflow のみ未設置だった。

## 挙動
- dependabot の patch/minor PR: required checks（backend / frontend）通過後に自動 squash マージ
- major PR: 自動マージせず手動判断

## 検証
- actionlint パス
- quantum-katas 等 9 リポで同一内容が稼働中